### PR TITLE
Fixing horizon in GymEnv creation

### DIFF
--- a/rllab/envs/gym_env.py
+++ b/rllab/envs/gym_env.py
@@ -170,10 +170,8 @@ def pass_params(env_name, sumo_params, type_params, env_params, net_params,
                 initial_config, scenario):
     global env_version_num
 
-    num_steps = 500
     env_version_num += 1
-    if "num_steps" in env_params.additional_params:
-        num_steps = env_params.additional_params["num_steps"]
+    num_steps = env_params.horizon
     register(
         id=env_name+'-v'+str(env_version_num),
         entry_point='flow.envs:'+env_name,


### PR DESCRIPTION
Horizon is stored as an attribute in the EnvParams object, so this should be updated accordingly. Otherwise steps default to 500 and won't change when EnvParams.horizon changes